### PR TITLE
[OUT-1434]: Added properties to the dialog

### DIFF
--- a/src/dialog.ts
+++ b/src/dialog.ts
@@ -44,6 +44,8 @@ export class DialogService {
 
     const dialogElement = document.createElement("div");
     dialogElement.classList.add(classes.wrapper);
+    dialogElement.setAttribute("aria-labelledby", "modal-title");
+    dialogElement.setAttribute("aria-describedby", "modal-content")
     dialogElement.setAttribute("role", "dialog");
     dialogElement.setAttribute("aria-modal", "true");
     dialogElement.setAttribute("aria-label", options.ariaLabel);


### PR DESCRIPTION
When the modal dialog is activated, keyboard focus is not placed on/in it. Element description: Grid Columns modal. Description of the issue: Keyboard focus is not moved to the modal when opened. Users must tab through the all content underlying to reach the modal. Note: Focus remains in the modal when focus is manually moved into the modal. Steps to reproduce: Activate the "Choose grid columns" link.
https://liaison-intl.atlassian.net/jira/software/c/projects/OUT/issues/OUT-1434